### PR TITLE
[fix typo] valeurs affichées versus valeurs sélectionnées

### DIFF
--- a/src/EditorCurrentSelector.jsx
+++ b/src/EditorCurrentSelector.jsx
@@ -41,10 +41,10 @@ export default function EditorCurrentSelector({id, value, onChange = null}) {
         <option value={"80A"}>80A</option>
         <option value={"90A"}>90A</option>
         <option value={"100A"}>100A</option>
-        <option value={"125A"}>100A</option>
+        <option value={"125A"}>125A</option>
         <option value={"160A"}>160A</option>
-        <option value={"180A"}>100A</option>
-        <option value={"240A"}>100A</option>
+        <option value={"180A"}>180A</option>
+        <option value={"240A"}>240A</option>
         <option value={"250A"}>250A</option>
     </select>
 }


### PR DESCRIPTION
Bonjour,

pour info un petit fix sur quelques typos, ici sur les valeurs affichées qui sont incorrectes avec leur valeur sélectionnée : `100A` à la place de `125A`, `180A` ou `240A`

https://github.com/pantaflex44/Tiquettes/blob/e16ceb6297fd1f4329d414b0700b4071e73f8e99/src/EditorCurrentSelector.jsx#L44-L47

