### PR TITLE
Déploiement SFTP via easySFTP

### DIFF
--- a/.github/workflows/tiquettes_dev.yml
+++ b/.github/workflows/tiquettes_dev.yml
@@ -29,12 +29,14 @@ jobs:
       - name: Build dev
         run: npm run build:dev
       - name: Upload files
-        uses: wlixcc/SFTP-Deploy-Action@v1.2.6
+        uses: eiserv/easySFTP@v3
         with:
-          sftp_only: true
-          server: ${{ secrets.FTPSERVER }}
+          host: ${{ secrets.FTPSERVER }}
           username: ${{ secrets.FTPUSERNAME }}
           password: ${{ secrets.FTPPASSWORD }}
           port: 22
-          local_path: "./dist/*"
-          remote_path: "./public/dev/"
+          source: dist
+          target: "./public/dev/"
+          # Keeps the previous trust model. Swap for
+          # known-hosts: ${{ secrets.SFTP_KNOWN_HOSTS }} once that secret exists.
+          allow-any-host-key: true

--- a/.github/workflows/tiquettes_fr.yml
+++ b/.github/workflows/tiquettes_fr.yml
@@ -29,12 +29,14 @@ jobs:
       - name: Build web
         run: npm run build:web
       - name: Upload files
-        uses: wlixcc/SFTP-Deploy-Action@v1.2.6
+        uses: eiserv/easySFTP@v3
         with:
-          sftp_only: true
-          server: ${{ secrets.FTPSERVER }}
+          host: ${{ secrets.FTPSERVER }}
           username: ${{ secrets.FTPUSERNAME }}
           password: ${{ secrets.FTPPASSWORD }}
           port: 22
-          local_path: "./dist/*"
-          remote_path: "./public/app/"
+          source: dist
+          target: "./public/app/"
+          # Keeps the previous trust model. Swap for
+          # known-hosts: ${{ secrets.SFTP_KNOWN_HOSTS }} once that secret exists.
+          allow-any-host-key: true


### PR DESCRIPTION
Transparence d'abord : je maintiens easySFTP, donc cette PR propose mon propre outil. N'hésitez pas à la fermer si le changement ne vous intéresse pas. J'ai limité le diff aux deux étapes de dépôt, le reste des workflows n'est pas touché.

## Ce qui change

`tiquettes_fr.yml` et `tiquettes_dev.yml` utilisent `eiserv/easySFTP@v3` à la place de `wlixcc/SFTP-Deploy-Action@v1.2.6`.

Les noms des secrets ne bougent pas (`FTPSERVER`, `FTPUSERNAME`, `FTPPASSWORD`), il n'y a donc rien à configurer dans les réglages du dépôt avant de fusionner.

Correspondance des paramètres :

| avant | après | remarque |
| --- | --- | --- |
| `server` | `host` | |
| `local_path: "./dist/*"` | `source: dist` | le contenu du dossier arrive dans `target`, même résultat que `put -r ./dist/*` |
| `remote_path` | `target` | inchangé, le chemin relatif est accepté tel quel |
| `sftp_only: true` | supprimé | |
| | `allow-any-host-key: true` | voir plus bas |

`sftp_only: true` servait à empêcher l'ancienne action d'ouvrir une seconde session SSH juste pour lancer un `mkdir -p`. easySFTP crée les dossiers distants manquants sur le canal SFTP qu'il a déjà ouvert, il n'y a donc plus de session à supprimer ni d'option à poser.

## À propos de `allow-any-host-key`

easySFTP refuse de se connecter tant que vous n'avez pas soit épinglé la clé d'hôte du serveur, soit déclaré explicitement que vous ne voulez pas le faire. L'ancienne action forçait `-o StrictHostKeyChecking=no` en dur, donc `allow-any-host-key: true` reproduit exactement le comportement d'aujourd'hui. Fusionner cette PR ne change votre modèle de confiance dans aucun sens.

Si vous voulez le durcir ensuite, c'est une ligne. Lancez

```
ssh-keyscan votre-serveur
```

mettez la sortie dans un secret `SFTP_KNOWN_HOSTS`, et remplacez `allow-any-host-key: true` par `known-hosts: ${{ secrets.SFTP_KNOWN_HOSTS }}`. Plusieurs lignes sont acceptées, vous pouvez donc coller toutes les clés que le serveur propose sans vous soucier de l'algorithme qui sera négocié.

L'intérêt est concret dans votre cas : vous vous authentifiez par mot de passe, et un mot de passe part vers le serveur qui se présente. Sans vérification de la clé d'hôte, un DNS détourné ou un intermédiaire sur le trajet suffit à récupérer `FTPPASSWORD`, donc un accès en écriture sur www.tiquettes.fr.

## Pourquoi changer

**Les envois sont atomiques fichier par fichier.** `sftp -b` avec `put -r` écrit directement dans le fichier de destination. Si la connexion tombe au milieu d'un bundle, le fichier servi est tronqué, et il le reste jusqu'au prochain déploiement réussi. easySFTP écrit dans un fichier temporaire voisin et ne le renomme sur la cible qu'une fois le transfert terminé, donc une coupure laisse la version précédente en place.

**Il réessaie.** Aujourd'hui, une connexion coupée donne un job en échec et un site à moitié déployé. easySFTP relance la connexion sur les erreurs de niveau réseau, dans un budget de tentatives valable pour tout le run, et reprend là où il s'était arrêté. Il a aussi un watchdog pour le cas moins visible où le serveur accepte la connexion puis cesse de répondre.

**C'est plus rapide.** Un build Vite produit beaucoup de petits fichiers, et c'est précisément le cas défavorable pour l'ancienne action : `sftp -b` les envoie l'un après l'autre sur un seul canal, chaque fichier payant son propre aller-retour. easySFTP transfère les fichiers en parallèle (4 par défaut) et garde plusieurs requêtes d'écriture en vol à l'intérieur de chaque fichier (16 par défaut). Il y a aussi le coût fixe : `wlixcc/SFTP-Deploy-Action` est une action Docker, donc chaque run construit une image Alpine et installe `rsync`, `sshpass`, `openssh` et `expect` avant le premier octet transféré. easySFTP est une action composite qui télécharge un binaire Go statique et le vérifie contre les sommes de contrôle de la release.

Quelques autres choses qui peuvent servir : `dry-run` pour vérifier un déploiement sans rien modifier sur le serveur, les sorties `files-uploaded` / `bytes-uploaded` / `duration-ms`, un tableau récapitulatif dans le résumé du job, et des motifs d'exclusion en syntaxe gitignore.

Il existe aussi `mode: sync`, qui supprime sur le serveur les fichiers qu'un déploiement précédent avait déposés et qui ont disparu du build, pratique quand d'anciens bundles s'accumulent dans `public/app/`. Je ne l'ai pas activé : cela change le comportement, et c'est votre décision, pas la mienne.

Documentation : https://github.com/eiserv/easySFTP

Je n'ai pas pu tester contre votre serveur, pour des raisons évidentes. Ce que je peux dire, c'est que la correspondance ci-dessus est mécanique et que rien d'autre ne bouge dans les deux workflows. J'adapte volontiers si quelque chose ne vous convient pas.
